### PR TITLE
Bloquer démarrage SMED tant que les tâches externes ne sont pas validées

### DIFF
--- a/SMED_Performance_V1_durable_params (4).html
+++ b/SMED_Performance_V1_durable_params (4).html
@@ -3286,9 +3286,27 @@ html += `
       }
     };
 
+    const areAllExternalTasksDone = () => {
+      if (!Array.isArray(operators) || operators.length === 0) {
+        const hasExternalSteps = Array.isArray(settings?.standardSteps)
+          && settings.standardSteps.some((step) => step?.type === "external");
+        return !hasExternalSteps;
+      }
+      const externalSteps = operators.flatMap((operator) => (Array.isArray(operator.steps) ? operator.steps : []))
+        .filter((step) => step?.type === "external");
+      if (externalSteps.length === 0) {
+        return true;
+      }
+      return externalSteps.every((step) => step && step.status === "done");
+    };
+
     const updateSmedStarted = () => {
       const hasDate = Boolean(ipcDate && ipcDate.value);
       const hasTime = Boolean(ipcTime && ipcTime.value);
+      if (!isSmedStarted && hasDate && hasTime && !areAllExternalTasksDone()) {
+        alert("Impossible de démarrer: valider toutes les tâches externes avant de lancer le chrono.");
+        return;
+      }
       const newIsSmedStarted = hasDate && hasTime;
       isSmedStarted = newIsSmedStarted;
       if (productInput) {


### PR DESCRIPTION
### Motivation
- Imposer la discipline SMED en empêchant le démarrage du chrono tant que des tâches de type `external` ne sont pas marquées comme `done`.
- Respecter la contrainte: ne pas modifier la logique de validation existante des étapes ni l'UI au-delà du blocage minimal demandé.

### Description
- Ajout d'une fonction locale `areAllExternalTasksDone()` qui retourne `true` si aucune étape externe n'existe ou si toutes les étapes externes présentes ont `status === "done"`, en se basant uniquement sur l'état existant (`operators` / `settings.standardSteps`).
- Ajout d'une garde au début de `updateSmedStarted()` : si la date/heure d'IPC est saisie et que `areAllExternalTasksDone()` est `false`, affiche une `alert("Impossible de démarrer: valider toutes les tâches externes avant de lancer le chrono.")` et annule le démarrage.
- Aucune autre logique ou UI n'a été modifiée (pas de changement sur les styles, le rendu du bouton, la logique pause/reprise, l'onglet Analyse, les exports ou la validation interne des étapes).

### Testing
- Aucun test automatisé n'a été exécuté (aucune suite CI ou test scriptée lancée).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f40ab688832db917ae623854cead)